### PR TITLE
Update `.gitignore` to ignore Jetbrains like IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
+#
+/.idea
+
 # User-specific files
 *.rsuser
 *.suo


### PR DESCRIPTION
This adds a new custom whilelist for ignoring `.idea` folder in the repository to ignore files generated by Jetbrains like IDEs.